### PR TITLE
Fixed 'pets' not tracking # of pets

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -203,11 +203,11 @@ class LockPicker
     end
 
     if @make_pets
-      case bput("put my #{box} in my #{@settings.picking_pet_box_source}", 'You put your .* in your ', "You just can\'t get", "There isn\'t any more")
+      case bput("put my #{box} in my #{@settings.picking_pet_box_source}", 'You put your', "You just can\'t get", "There isn\'t any more")
       when "You just can\'t get", "There isn\'t any more"
         bput("put my #{box} in my #{@settings.picking_box_source}", 'You put your')
         @pet_count = @pet_goal
-      when 'You put your .* in your '
+      when 'You put your'
         @pet_count += 1
       end
       return


### PR DESCRIPTION
In the attempt_open function 'if @make_pets' was getting called but did not match when the pet box was stored in the picking_pet_box_source container. Therefore @pet_count was never increased and it would turn all source boxes into pet boxes. The issue is fixed with this change.

This is the subject of issue ticket #1561.